### PR TITLE
:sparkles: move mappingErrorHandling config to a parent config named …

### DIFF
--- a/mapping-jobs/pilot1-hsjd/pilot1-hsjd.json
+++ b/mapping-jobs/pilot1-hsjd/pilot1-hsjd.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot1-hsjd/patient-mapping",

--- a/mapping-jobs/pilot1/pilot1-preop-backup.json
+++ b/mapping-jobs/pilot1/pilot1-preop-backup.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot1/patient-mapping",

--- a/mapping-jobs/pilot1/pilot1-preop.json
+++ b/mapping-jobs/pilot1/pilot1-preop.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot1/patient-mapping",

--- a/mapping-jobs/pilot1/pilot1.json
+++ b/mapping-jobs/pilot1/pilot1.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot1/patient-mapping",

--- a/mapping-jobs/pilot2-unipd/pilot2-unipd-mappingjob-deploy.json
+++ b/mapping-jobs/pilot2-unipd/pilot2-unipd-mappingjob-deploy.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot2-unipd/patient-mapping",

--- a/mapping-jobs/pilot2-unipd/pilot2-unipd-mappingjob.json
+++ b/mapping-jobs/pilot2-unipd/pilot2-unipd-mappingjob.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot2-unipd/patient-mapping",

--- a/mapping-jobs/pilot2/pilot2-mappingjob-deploy.json
+++ b/mapping-jobs/pilot2/pilot2-mappingjob-deploy.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot2/patient-mapping",

--- a/mapping-jobs/pilot2/pilot2-mappingjob.json
+++ b/mapping-jobs/pilot2/pilot2-mappingjob.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot2/patient-mapping",

--- a/mapping-jobs/pilot3-p1/pilot3-p1-mappingjob-deploy.json
+++ b/mapping-jobs/pilot3-p1/pilot3-p1-mappingjob-deploy.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "halt"
   },
-  "mappingErrorHandling": "halt",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "halt"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p1/patient-mapping",

--- a/mapping-jobs/pilot3-p1/pilot3-p1-mappingjob.json
+++ b/mapping-jobs/pilot3-p1/pilot3-p1-mappingjob.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p1/patient-mapping",

--- a/mapping-jobs/pilot3-p2/pilot3-hus-deploy.json
+++ b/mapping-jobs/pilot3-p2/pilot3-hus-deploy.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p2/patient-mapping",

--- a/mapping-jobs/pilot3-p2/pilot3-p2-mappingjob.json
+++ b/mapping-jobs/pilot3-p2/pilot3-p2-mappingjob.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p2/patient-mapping",

--- a/mapping-jobs/pilot3-p2/pilot3-p2-partial.json
+++ b/mapping-jobs/pilot3-p2/pilot3-p2-partial.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p2/patient-mapping",

--- a/mapping-jobs/pilot3-p3/pilot3-p3-mappingjob.json
+++ b/mapping-jobs/pilot3-p3/pilot3-p3-mappingjob.json
@@ -13,7 +13,9 @@
     "fhirRepoUrl": "${FHIR_REPO_URL}",
     "writeErrorHandling": "continue"
   },
-  "mappingErrorHandling": "continue",
+  "dataProcessingSettings": {
+    "mappingErrorHandling": "continue"
+  },
   "mappings": [
     {
       "mappingRef": "https://aiccelerate.eu/fhir/mappings/pilot3-p3/patient-mapping",


### PR DESCRIPTION
…dataProcessingSettings in current mapping jobs so that toFhir works with the repo